### PR TITLE
chore: push workflow and template updates to new branch

### DIFF
--- a/.github/workflows/pr-validate-profile.yml
+++ b/.github/workflows/pr-validate-profile.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Determine changed files
         id: changed
         run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- content/consultants/*.md)
+          # only include newly added consultant files
+          CHANGED=$(git diff --diff-filter=A --name-only origin/${{ github.base_ref }}...HEAD -- content/consultants/*.md | paste -sd ' ' -)
           echo "CHANGED_FILES=$CHANGED" >> $GITHUB_ENV
       - name: Validate GitHub handle in front-matter
         if: env.CHANGED_FILES != ''

--- a/.github/workflows/sync-on-main.yml
+++ b/.github/workflows/sync-on-main.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Determine changed consultant files
         id: changed
         run: |
-          CHANGED=$(git diff --name-only ${{ github.event.before }}...${{ github.sha }} -- content/consultants/*.md)
+          # join changed file paths into a single space-delimited string
+          CHANGED=$(git diff --name-only ${{ github.event.before }}...${{ github.sha }} -- content/consultants/*.md | paste -sd ' ' -)
           echo "CHANGED_FILES=$CHANGED" >> $GITHUB_ENV
 
       - name: Sync changed profiles


### PR DESCRIPTION
## problem
profile validation runs for updates on profile.md (not just on the initial pr.)
## resolution
update it so that pr-validate-profile only runs if the profile.md is _added_ in the PR.